### PR TITLE
Feature/145753: Ajustes informacoes adicionais

### DIFF
--- a/src/actions/atualizar-formulario-completo-ue.test.ts
+++ b/src/actions/atualizar-formulario-completo-ue.test.ts
@@ -222,12 +222,13 @@ describe("atualizarFormularioCompletoUE action", () => {
                     etapa_escolar: "Fundamental II",
                     frequencia_escolar: "Regular",
                     interacao_ambiente_escolar: "Boa",
+                    nacionalidade: "Brasileira",
+                    pessoa_com_deficiencia: false,
                 },
             ],
             motivacao_ocorrencia: ["Bullying"],
-            redes_protecao_acompanhamento: "CRAS",
             notificado_conselho_tutelar: true,
-            acompanhado_naapa: false,
+            ocorrencia_acompanhada_pelo: "naapa",
         };
 
         const mockResponse = {

--- a/src/actions/atualizar-info-agressor.test.ts
+++ b/src/actions/atualizar-info-agressor.test.ts
@@ -32,12 +32,13 @@ describe("atualizarInfoAgressor action", () => {
                 frequencia_escolar: "transferido_estadual",
                 interacao_ambiente_escolar:
                     "Como é a interação da pessoa agressora no ambiente escolar?",
+                nacionalidade: "Brasileira",
+                pessoa_com_deficiencia: false,
             },
         ],
         motivacao_ocorrencia: ["homofobia", "racismo"],
-        redes_protecao_acompanhamento: "CRAS, NAAPA",
         notificado_conselho_tutelar: true,
-        acompanhado_naapa: false,
+        ocorrencia_acompanhada_pelo: "naapa",
     };
     const mockAuthToken = "test-token";
 
@@ -64,13 +65,14 @@ describe("atualizarInfoAgressor action", () => {
                         frequencia_escolar: "transferido_estadual",
                         interacao_ambiente_escolar:
                             "Como é a interação da pessoa agressora no ambiente escolar?",
+                        nacionalidade: "Brasileira",
+                        pessoa_com_deficiencia: false,
                     },
                 ],
                 motivacao_ocorrencia: ["homofobia", "racismo"],
                 motivacao_ocorrencia_display: "Homofobia, Racismo",
-                redes_protecao_acompanhamento: "CRAS, NAAPA",
                 notificado_conselho_tutelar: true,
-                acompanhado_naapa: false,
+                ocorrencia_acompanhada_pelo: "naapa",
             },
         };
         vi.mocked(apiIntercorrencias.put).mockResolvedValue(mockResponse);
@@ -224,9 +226,8 @@ describe("atualizarInfoAgressor action", () => {
                     }),
                 ],
                 motivacao_ocorrencia: ["homofobia", "racismo"],
-                redes_protecao_acompanhamento: "CRAS, NAAPA",
                 notificado_conselho_tutelar: true,
-                acompanhado_naapa: false,
+                ocorrencia_acompanhada_pelo: "naapa",
             }),
             expect.any(Object),
         );

--- a/src/actions/atualizar-info-agressor.ts
+++ b/src/actions/atualizar-info-agressor.ts
@@ -1,13 +1,13 @@
 "use server";
 
-import { cookies } from "next/headers";
-import { AxiosError } from "axios";
 import apiIntercorrencias from "@/lib/axios-intercorrencias";
 import { InfoAgressorBody, InfoAgressorResponse } from "@/types/info-agressor";
+import { AxiosError } from "axios";
+import { cookies } from "next/headers";
 
 export const atualizarInfoAgressor = async (
     uuid: string,
-    body: InfoAgressorBody
+    body: InfoAgressorBody,
 ): Promise<
     | { success: true; data: InfoAgressorResponse }
     | { success: false; error: string }
@@ -30,7 +30,7 @@ export const atualizarInfoAgressor = async (
                 headers: {
                     Authorization: `Bearer ${authToken}`,
                 },
-            }
+            },
         );
 
         return { success: true, data: response.data };

--- a/src/actions/obter-ocorrencia.ts
+++ b/src/actions/obter-ocorrencia.ts
@@ -41,11 +41,12 @@ export type OcorrenciaDetalheAPI = {
         etapa_escolar: string;
         frequencia_escolar: string;
         interacao_ambiente_escolar: string;
+        nacionalidade: string;
+        pessoa_com_deficiencia: boolean;
     }>;
     motivacao_ocorrencia_display?: Array<{ value: string; label: string }>;
-    redes_protecao_acompanhamento?: string;
     notificado_conselho_tutelar?: boolean;
-    acompanhado_naapa?: boolean;
+    ocorrencia_acompanhada_pelo?: string;
 };
 
 export async function obterOcorrencia(

--- a/src/actions/obter-ocorrencia.ts
+++ b/src/actions/obter-ocorrencia.ts
@@ -46,7 +46,11 @@ export type OcorrenciaDetalheAPI = {
     }>;
     motivacao_ocorrencia_display?: Array<{ value: string; label: string }>;
     notificado_conselho_tutelar?: boolean;
-    ocorrencia_acompanhada_pelo?: string;
+    ocorrencia_acompanhada_pelo?:
+        | "naapa"
+        | "comissao_mediacao_conflitos"
+        | "supervisao_escolar"
+        | "cefai";
 };
 
 export async function obterOcorrencia(

--- a/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/Envolvidos.test.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/Envolvidos.test.tsx
@@ -38,6 +38,8 @@ const EMPTY_PESSOA = {
     etapaEscolar: "",
     frequenciaEscolar: "",
     interacaoAmbienteEscolar: "",
+    nacionalidade: "",
+    pessoaComDeficiencia: "",
 };
 
 function Wrapper({
@@ -53,7 +55,6 @@ function Wrapper({
         defaultValues: {
             pessoasAgressoras: defaultValues ?? [EMPTY_PESSOA],
             motivoOcorrencia: [],
-            redesProtecao: "",
             notificadoConselhoTutelar: undefined,
             acompanhadoNAAPA: undefined,
         },
@@ -79,13 +80,13 @@ describe("Envolvidos", () => {
         render(<Wrapper />);
 
         expect(
-            screen.getAllByLabelText(/nome da pessoa envolvida/i),
+            screen.getAllByLabelText(/Qual o nome da pessoa\?/i),
         ).toHaveLength(1);
         expect(screen.getAllByLabelText(/Qual a idade\?/i)).toHaveLength(1);
         expect(screen.getAllByText(/Qual o gênero\?/i)).toHaveLength(1);
-        expect(
-            screen.getAllByText(/Qual o grupo étnico-racial\?/i),
-        ).toHaveLength(1);
+        expect(screen.getAllByText(/Raça\/cor auto declarada/i)).toHaveLength(
+            1,
+        );
         expect(screen.getAllByText(/Qual a etapa escolar\?/i)).toHaveLength(1);
         expect(
             screen.getAllByText(/Qual a frequência escolar\?/i),
@@ -113,7 +114,7 @@ describe("Envolvidos", () => {
         await user.click(addButton);
 
         expect(
-            screen.getAllByLabelText(/nome da pessoa envolvida/i),
+            screen.getAllByLabelText(/Qual o nome da pessoa\?/i),
         ).toHaveLength(2);
         expect(screen.getAllByLabelText(/Qual a idade\?/i)).toHaveLength(2);
     });
@@ -138,7 +139,7 @@ describe("Envolvidos", () => {
         );
 
         expect(
-            screen.getAllByLabelText(/nome da pessoa envolvida/i),
+            screen.getAllByLabelText(/Qual o nome da pessoa\?/i),
         ).toHaveLength(2);
 
         const removeButtons = screen.getAllByRole("button", {
@@ -147,7 +148,7 @@ describe("Envolvidos", () => {
         await user.click(removeButtons[0]);
 
         expect(
-            screen.getAllByLabelText(/nome da pessoa envolvida/i),
+            screen.getAllByLabelText(/Qual o nome da pessoa\?/i),
         ).toHaveLength(1);
     });
 
@@ -163,7 +164,7 @@ describe("Envolvidos", () => {
         render(<Wrapper disabled={true} />);
 
         const nomeInput = screen.getAllByLabelText(
-            /nome da pessoa envolvida/i,
+            /Qual o nome da pessoa\?/i,
         )[0];
         const idadeInput = screen.getAllByLabelText(/Qual a idade\?/i)[0];
         const addButton = screen.getByRole("button", {
@@ -194,7 +195,7 @@ describe("Envolvidos", () => {
         );
 
         const nomeInput = screen.getAllByLabelText(
-            /nome da pessoa envolvida/i,
+            /Qual o nome da pessoa\?/i,
         )[0];
         const idadeInput = screen.getAllByLabelText(/Qual a idade\?/i)[0];
 

--- a/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/Envolvidos.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/Envolvidos.tsx
@@ -34,6 +34,8 @@ const EMPTY_PESSOA = {
     etapaEscolar: "",
     frequenciaEscolar: "",
     interacaoAmbienteEscolar: "",
+    nacionalidade: "",
+    pessoaComDeficiencia: "",
 };
 
 export default function Envolvidos({
@@ -60,7 +62,7 @@ export default function Envolvidos({
                             render={({ field }) => (
                                 <FormItem>
                                     <FormLabel disabled={disabled}>
-                                        Qual o nome da pessoa envolvida?*
+                                        Qual o nome da pessoa?*
                                     </FormLabel>
                                     <FormControl>
                                         <Input
@@ -139,7 +141,7 @@ export default function Envolvidos({
                             render={({ field }) => (
                                 <FormItem>
                                     <FormLabel disabled={disabled}>
-                                        Qual o grupo étnico-racial?*
+                                        Raça/cor auto declarada*
                                     </FormLabel>
                                     <Select
                                         onValueChange={field.onChange}
@@ -236,6 +238,61 @@ export default function Envolvidos({
                                             )}
                                         </SelectContent>
                                     </Select>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-4 items-start md:grid-cols-3">
+                        <FormField
+                            control={control}
+                            name={`pessoasAgressoras.${index}.pessoaComDeficiencia`}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel disabled={disabled}>
+                                        Pessoa com deficiência?*
+                                    </FormLabel>
+                                    <Select
+                                        onValueChange={field.onChange}
+                                        value={field.value}
+                                        disabled={disabled}
+                                    >
+                                        <FormControl>
+                                            <SelectTrigger>
+                                                <SelectValue placeholder="Selecione" />
+                                            </SelectTrigger>
+                                        </FormControl>
+                                        <SelectContent>
+                                            <SelectItem value="Sim">
+                                                Sim
+                                            </SelectItem>
+                                            <SelectItem value="Não">
+                                                Não
+                                            </SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={control}
+                            name={`pessoasAgressoras.${index}.nacionalidade`}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel disabled={disabled}>
+                                        Qual a nacionalidade?*
+                                    </FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            disabled={disabled}
+                                            placeholder="Digite aqui..."
+                                            maxLength={100}
+                                            {...field}
+                                        />
+                                    </FormControl>
                                     <FormMessage />
                                 </FormItem>
                             )}

--- a/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/Envolvidos.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/Envolvidos.tsx
@@ -1,4 +1,5 @@
 import { CategoriasDisponiveisAPI } from "@/actions/categorias-disponiveis";
+import InfoTooltip from "@/components/login/InfoTooltip";
 import { Button } from "@/components/ui/button";
 import {
     FormControl,
@@ -283,12 +284,15 @@ export default function Envolvidos({
                             render={({ field }) => (
                                 <FormItem>
                                     <FormLabel disabled={disabled}>
-                                        Qual a nacionalidade?*
+                                        <span className="flex items-center gap-1">
+                                            Nacionalidade*
+                                            <InfoTooltip content="A nacionalidade se refere ao país ao qual a pessoa pertence." />
+                                        </span>
                                     </FormLabel>
                                     <FormControl>
                                         <Input
                                             disabled={disabled}
-                                            placeholder="Digite aqui..."
+                                            placeholder="Digite a nacionalidade..."
                                             maxLength={100}
                                             {...field}
                                         />

--- a/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/index.test.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/index.test.tsx
@@ -43,7 +43,7 @@ describe("InformacoesAdicionais", () => {
         const motivoLabel = options?.motivoLabel ?? /Bullying/i;
 
         const nomesInputs = screen.getAllByLabelText(
-            /Qual o nome da pessoa envolvida\?/i,
+            /Qual o nome da pessoa\?/i,
         );
         await user.type(nomesInputs[0], "João Silva");
         const idadesInputs = screen.getAllByLabelText(/Qual a idade\?/i);
@@ -58,7 +58,7 @@ describe("InformacoesAdicionais", () => {
         );
 
         const grupoTrigger = screen.getByRole("combobox", {
-            name: /Qual o grupo étnico-racial\?/i,
+            name: /Raça\/cor auto declarada/i,
         });
         await user.click(grupoTrigger);
         await user.click(await screen.findByRole("option", { name: /Pardo/i }));
@@ -87,13 +87,21 @@ describe("InformacoesAdicionais", () => {
             "Boa interação",
         );
         await user.type(
-            screen.getByLabelText(/Quais órgãos da rede de proteção/i),
-            "CRAS, NAAPA",
+            screen.getByLabelText(/Qual a nacionalidade\?/i),
+            "Brasileira",
         );
 
-        const radioSim = screen.getAllByRole("radio", { name: /Sim/i });
+        const deficienciaTrigger = screen.getByRole("combobox", {
+            name: /Pessoa com deficiência\?/i,
+        });
+        await user.click(deficienciaTrigger);
+        await user.click(await screen.findByRole("option", { name: /^Sim$/i }));
+
+        const radioSim = screen.getAllByRole("radio", { name: /^Sim$/i });
         await user.click(radioSim[0]);
-        await user.click(radioSim[1]);
+
+        const radioNAAPA = screen.getByRole("radio", { name: /NAAPA/i });
+        await user.click(radioNAAPA);
 
         const motivoButton = screen.getByRole("button", { name: /Selecione/i });
         await user.click(motivoButton);
@@ -164,15 +172,13 @@ describe("InformacoesAdicionais", () => {
         renderComponent();
 
         expect(
-            screen.getAllByLabelText(/nome da pessoa envolvida/i).length,
+            screen.getAllByLabelText(/Qual o nome da pessoa\?/i).length,
         ).toBeGreaterThanOrEqual(1);
         expect(
             screen.getByText(/O que motivou a ocorrência/i),
         ).toBeInTheDocument();
-        expect(
-            screen.getByText(/notificada ao Conselho Tutelar/i),
-        ).toBeInTheDocument();
-        expect(screen.getByText(/acompanhada pelo NAAPA/i)).toBeInTheDocument();
+        expect(screen.getByText(/notificada ao CT/i)).toBeInTheDocument();
+        expect(screen.getByText(/acompanhada pelo:/i)).toBeInTheDocument();
         expect(
             screen.getByRole("button", { name: /Anterior/i }),
         ).toBeInTheDocument();
@@ -209,9 +215,8 @@ describe("InformacoesAdicionais", () => {
                     },
                 ],
                 motivoOcorrencia: ["outros"],
-                redesProtecao: "CRAS",
                 notificadoConselhoTutelar: "Sim",
-                acompanhadoNAAPA: "Não",
+                acompanhadoNAAPA: "naapa",
             },
             setFormData: mockSetFormData,
         });
@@ -219,7 +224,7 @@ describe("InformacoesAdicionais", () => {
         renderComponent();
 
         const nomesInputs = screen.getAllByLabelText(
-            /Qual o nome da pessoa envolvida\?/i,
+            /Qual o nome da pessoa\?/i,
         );
         expect(nomesInputs[0]).toHaveValue("João Silva");
         const idadesInputs = screen.getAllByLabelText(/Qual a idade\?/i);
@@ -234,7 +239,7 @@ describe("InformacoesAdicionais", () => {
         expect(proximoButton).toBeDisabled();
 
         const nomesInputs = screen.getAllByLabelText(
-            /Qual o nome da pessoa envolvida\?/i,
+            /Qual o nome da pessoa\?/i,
         );
         await user.type(nomesInputs[0], "João Silva");
 
@@ -245,12 +250,14 @@ describe("InformacoesAdicionais", () => {
         const user = userEvent.setup();
         renderComponent();
 
-        const radioNao = screen.getAllByRole("radio", { name: /Não/i });
-        await user.click(radioNao[0]);
-        await user.click(radioNao[1]);
+        const radioNao = screen.getByRole("radio", { name: /Não/i });
+        await user.click(radioNao);
 
-        expect(radioNao[0]).toBeChecked();
-        expect(radioNao[1]).toBeChecked();
+        expect(radioNao).toBeChecked();
+
+        const radioNAAPA = screen.getByRole("radio", { name: /NAAPA/i });
+        await user.click(radioNAAPA);
+        expect(radioNAAPA).toBeChecked();
     });
 
     it("deve chamar onNext e setFormData ao submeter formulário válido", async () => {
@@ -258,7 +265,7 @@ describe("InformacoesAdicionais", () => {
         renderComponent();
 
         const nomesInputs = screen.getAllByLabelText(
-            /Qual o nome da pessoa envolvida\?/i,
+            /Qual o nome da pessoa\?/i,
         );
         await user.type(nomesInputs[0], "João Silva");
         const idadesInputs = screen.getAllByLabelText(/Qual a idade\?/i);
@@ -273,7 +280,7 @@ describe("InformacoesAdicionais", () => {
         );
 
         const grupoTrigger = screen.getByRole("combobox", {
-            name: /Qual o grupo étnico-racial\?/i,
+            name: /Raça\/cor auto declarada/i,
         });
         await user.click(grupoTrigger);
         await user.click(await screen.findByRole("option", { name: /Pardo/i }));
@@ -302,13 +309,21 @@ describe("InformacoesAdicionais", () => {
             "Boa interação com todos",
         );
         await user.type(
-            screen.getByLabelText(/Quais órgãos da rede de proteção/i),
-            "CRAS e Conselho Tutelar",
+            screen.getByLabelText(/Qual a nacionalidade\?/i),
+            "Brasileira",
         );
 
-        const radioSim = screen.getAllByRole("radio", { name: /Sim/i });
+        const deficienciaTrigger2 = screen.getByRole("combobox", {
+            name: /Pessoa com deficiência\?/i,
+        });
+        await user.click(deficienciaTrigger2);
+        await user.click(await screen.findByRole("option", { name: /^Sim$/i }));
+
+        const radioSim = screen.getAllByRole("radio", { name: /^Sim$/i });
         await user.click(radioSim[0]);
-        await user.click(radioSim[1]);
+
+        const radioNAAPA2 = screen.getByRole("radio", { name: /NAAPA/i });
+        await user.click(radioNAAPA2);
 
         const motivoButton = screen.getByRole("button", { name: /Selecione/i });
         await user.click(motivoButton);
@@ -405,7 +420,7 @@ describe("InformacoesAdicionais", () => {
                             ],
                             motivacao_ocorrencia: ["bullying"],
                             notificado_conselho_tutelar: true,
-                            acompanhado_naapa: true,
+                            ocorrencia_acompanhada_pelo: "naapa",
                         }),
                     }),
                     expect.any(Object),
@@ -537,12 +552,13 @@ describe("InformacoesAdicionais", () => {
                             etapaEscolar: "ensino_fundamental_2",
                             frequenciaEscolar: "regular",
                             interacaoAmbienteEscolar: "Boa interação",
+                            nacionalidade: "Brasileira",
+                            pessoaComDeficiencia: "Sim",
                         },
                     ],
                     motivoOcorrencia: ["bullying"],
-                    redesProtecao: "CRAS, NAAPA",
                     notificadoConselhoTutelar: "Sim",
-                    acompanhadoNAAPA: "Sim",
+                    acompanhadoNAAPA: "naapa",
                 },
                 setFormData: mockSetFormData,
                 setSavedFormData: mockSetSavedFormData,
@@ -581,7 +597,6 @@ describe("InformacoesAdicionais", () => {
 
             expect(formData).toHaveProperty("pessoasAgressoras");
             expect(formData).toHaveProperty("motivoOcorrencia");
-            expect(formData).toHaveProperty("redesProtecao");
             expect(formData).toHaveProperty("notificadoConselhoTutelar");
             expect(formData).toHaveProperty("acompanhadoNAAPA");
         });
@@ -645,9 +660,7 @@ describe("InformacoesAdicionais", () => {
             );
 
             await user.type(
-                screen.getAllByLabelText(
-                    /Qual o nome da pessoa envolvida\?/i,
-                )[0],
+                screen.getAllByLabelText(/Qual o nome da pessoa\?/i)[0],
                 "João Silva",
             );
             await user.type(
@@ -664,7 +677,7 @@ describe("InformacoesAdicionais", () => {
             );
 
             const grupoTrigger = screen.getByRole("combobox", {
-                name: /Qual o grupo étnico-racial\?/i,
+                name: /Raça\/cor auto declarada/i,
             });
             await user.click(grupoTrigger);
             await user.click(
@@ -697,13 +710,25 @@ describe("InformacoesAdicionais", () => {
                 "Boa interação",
             );
             await user.type(
-                screen.getByLabelText(/Quais órgãos da rede de proteção/i),
-                "CRAS, NAAPA",
+                screen.getByLabelText(/Qual a nacionalidade\?/i),
+                "Brasileira",
             );
 
-            const radioSim = screen.getAllByRole("radio", { name: /Sim/i });
-            await user.click(radioSim[0]);
-            await user.click(radioSim[1]);
+            const deficienciaTrigger3 = screen.getByRole("combobox", {
+                name: /Pessoa com deficiência\?/i,
+            });
+            await user.click(deficienciaTrigger3);
+            await user.click(
+                await screen.findByRole("option", { name: /^Sim$/i }),
+            );
+
+            const radioSimSubmit = screen.getAllByRole("radio", {
+                name: /^Sim$/i,
+            });
+            await user.click(radioSimSubmit[0]);
+
+            const radioNAAPA3 = screen.getByRole("radio", { name: /NAAPA/i });
+            await user.click(radioNAAPA3);
 
             const motivoButton = screen.getByRole("button", {
                 name: /Selecione/i,
@@ -756,7 +781,7 @@ describe("InformacoesAdicionais", () => {
         renderComponent();
 
         const nomeInput = screen.getAllByLabelText(
-            /Qual o nome da pessoa envolvida\?/i,
+            /Qual o nome da pessoa\?/i,
         )[0];
         const idadeInput = screen.getAllByLabelText(/Qual a idade\?/i)[0];
         expect(nomeInput).toBeDisabled();

--- a/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/index.test.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/index.test.tsx
@@ -86,10 +86,7 @@ describe("InformacoesAdicionais", () => {
             screen.getByLabelText(/Como é a interação da pessoa no ambiente/i),
             "Boa interação",
         );
-        await user.type(
-            screen.getByLabelText(/Qual a nacionalidade\?/i),
-            "Brasileira",
-        );
+        await user.type(screen.getByPlaceholderText(/Digite a nacionalidade/i), "Brasileira");
 
         const deficienciaTrigger = screen.getByRole("combobox", {
             name: /Pessoa com deficiência\?/i,
@@ -308,10 +305,7 @@ describe("InformacoesAdicionais", () => {
             screen.getByLabelText(/Como é a interação da pessoa no ambiente/i),
             "Boa interação com todos",
         );
-        await user.type(
-            screen.getByLabelText(/Qual a nacionalidade\?/i),
-            "Brasileira",
-        );
+        await user.type(screen.getByPlaceholderText(/Digite a nacionalidade/i), "Brasileira");
 
         const deficienciaTrigger2 = screen.getByRole("combobox", {
             name: /Pessoa com deficiência\?/i,
@@ -710,7 +704,7 @@ describe("InformacoesAdicionais", () => {
                 "Boa interação",
             );
             await user.type(
-                screen.getByLabelText(/Qual a nacionalidade\?/i),
+                screen.getByPlaceholderText(/Digite a nacionalidade/i),
                 "Brasileira",
             );
 

--- a/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/index.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/index.tsx
@@ -11,7 +11,6 @@ import {
 import { toast } from "@/components/ui/headless-toast";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Textarea } from "@/components/ui/textarea";
 import { useAtualizarInfoAgressor } from "@/hooks/useAtualizarInfoAgressor";
 import { useCategoriasDisponiveis } from "@/hooks/useCategoriasDisponiveis";
 import { hasFormDataChanged } from "@/lib/formUtils";
@@ -70,10 +69,11 @@ const InformacoesAdicionais = forwardRef<
                           etapaEscolar: "",
                           frequenciaEscolar: "",
                           interacaoAmbienteEscolar: "",
+                          nacionalidade: "",
+                          pessoaComDeficiencia: "",
                       },
                   ],
             motivoOcorrencia: formData.motivoOcorrencia ?? [],
-            redesProtecao: formData.redesProtecao ?? "",
             notificadoConselhoTutelar:
                 formData.notificadoConselhoTutelar ?? undefined,
             acompanhadoNAAPA: formData.acompanhadoNAAPA ?? undefined,
@@ -105,7 +105,6 @@ const InformacoesAdicionais = forwardRef<
                 !hasFormDataChanged(currentValues, savedFormData, [
                     "pessoasAgressoras",
                     "motivoOcorrencia",
-                    "redesProtecao",
                     "notificadoConselhoTutelar",
                     "acompanhadoNAAPA",
                 ])
@@ -130,13 +129,15 @@ const InformacoesAdicionais = forwardRef<
                                 frequencia_escolar: pessoa.frequenciaEscolar,
                                 interacao_ambiente_escolar:
                                     pessoa.interacaoAmbienteEscolar,
+                                nacionalidade: pessoa.nacionalidade,
+                                pessoa_com_deficiencia:
+                                    pessoa.pessoaComDeficiencia === "Sim",
                             }),
                         ),
                         motivacao_ocorrencia: data.motivoOcorrencia,
-                        redes_protecao_acompanhamento: data.redesProtecao,
                         notificado_conselho_tutelar:
                             data.notificadoConselhoTutelar === "Sim",
-                        acompanhado_naapa: data.acompanhadoNAAPA === "Sim",
+                        ocorrencia_acompanhada_pelo: data.acompanhadoNAAPA,
                     },
                 },
                 {
@@ -210,34 +211,12 @@ const InformacoesAdicionais = forwardRef<
 
                     <FormField
                         control={form.control}
-                        name="redesProtecao"
-                        render={({ field }) => (
-                            <FormItem>
-                                <FormLabel disabled={disabled}>
-                                    Quais órgãos da rede de proteção já
-                                    acompanham o estudante?*
-                                </FormLabel>
-                                <FormControl>
-                                    <Textarea
-                                        disabled={disabled}
-                                        placeholder="Digite aqui..."
-                                        className="min-h-[100px]"
-                                        {...field}
-                                    />
-                                </FormControl>
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-
-                    <FormField
-                        control={form.control}
                         name="notificadoConselhoTutelar"
                         render={({ field }) => (
                             <FormItem>
                                 <FormLabel disabled={disabled}>
-                                    A ocorrência foi notificada ao Conselho
-                                    Tutelar?*
+                                    A ocorrência foi notificada ao CT (Conselho
+                                    Tutelar)?*
                                 </FormLabel>
                                 <FormControl>
                                     <div className="pt-2">
@@ -285,7 +264,7 @@ const InformacoesAdicionais = forwardRef<
                         render={({ field }) => (
                             <FormItem>
                                 <FormLabel disabled={disabled}>
-                                    A ocorrência é acompanhada pelo NAAPA?*
+                                    A ocorrência está sendo acompanhada pelo:
                                 </FormLabel>
                                 <FormControl>
                                     <div className="pt-2">
@@ -296,7 +275,7 @@ const InformacoesAdicionais = forwardRef<
                                             className="flex flex-col space-y-2"
                                         >
                                             <label className="flex items-center space-x-2 w-fit cursor-pointer">
-                                                <RadioGroupItem value="Sim" />
+                                                <RadioGroupItem value="naapa" />
                                                 <span
                                                     className={
                                                         disabled
@@ -304,11 +283,11 @@ const InformacoesAdicionais = forwardRef<
                                                             : "text-sm text-[#42474a]"
                                                     }
                                                 >
-                                                    Sim
+                                                    NAAPA
                                                 </span>
                                             </label>
                                             <label className="flex items-center space-x-2 w-fit cursor-pointer">
-                                                <RadioGroupItem value="Não" />
+                                                <RadioGroupItem value="comissao_mediacao_conflitos" />
                                                 <span
                                                     className={
                                                         disabled
@@ -316,7 +295,32 @@ const InformacoesAdicionais = forwardRef<
                                                             : "text-sm text-[#42474a]"
                                                     }
                                                 >
-                                                    Não
+                                                    Comissão de Mediação de
+                                                    Conflitos
+                                                </span>
+                                            </label>
+                                            <label className="flex items-center space-x-2 w-fit cursor-pointer">
+                                                <RadioGroupItem value="supervisao_escolar" />
+                                                <span
+                                                    className={
+                                                        disabled
+                                                            ? "text-sm text-[#B0B0B0]"
+                                                            : "text-sm text-[#42474a]"
+                                                    }
+                                                >
+                                                    Supervisão Escolar
+                                                </span>
+                                            </label>
+                                            <label className="flex items-center space-x-2 w-fit cursor-pointer">
+                                                <RadioGroupItem value="cefai" />
+                                                <span
+                                                    className={
+                                                        disabled
+                                                            ? "text-sm text-[#B0B0B0]"
+                                                            : "text-sm text-[#42474a]"
+                                                    }
+                                                >
+                                                    CEFAI
                                                 </span>
                                             </label>
                                         </RadioGroup>

--- a/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/schema.ts
+++ b/src/components/dashboard/CadastrarOcorrencia/InformacoesAdicionais/schema.ts
@@ -17,6 +17,13 @@ const pessoaAgressoraSchema = z.object({
         .string()
         .min(1, "Descrição da interação é obrigatória")
         .min(10, "Descrição deve ter no mínimo 10 caracteres"),
+    nacionalidade: z
+        .string()
+        .min(1, "Nacionalidade é obrigatória")
+        .max(100, "Nacionalidade deve ter no máximo 100 caracteres"),
+    pessoaComDeficiencia: z
+        .string()
+        .min(1, "Informe se a pessoa tem deficiência"),
 });
 
 export type PessoaAgressoraForm = z.infer<typeof pessoaAgressoraSchema>;
@@ -28,16 +35,15 @@ export const formSchema = z.object({
     motivoOcorrencia: z
         .array(z.string())
         .min(1, "Selecione pelo menos um motivo"),
-    redesProtecao: z
-        .string()
-        .min(1, "Informação sobre redes de proteção é obrigatória")
-        .min(10, "Descrição deve ter no mínimo 10 caracteres"),
     notificadoConselhoTutelar: z.enum(["Sim", "Não"], {
         required_error: "Selecione uma opção",
     }),
-    acompanhadoNAAPA: z.enum(["Sim", "Não"], {
-        required_error: "Selecione uma opção",
-    }),
+    acompanhadoNAAPA: z.enum(
+        ["naapa", "comissao_mediacao_conflitos", "supervisao_escolar", "cefai"],
+        {
+            required_error: "Selecione uma opção",
+        },
+    ),
 });
 
 export type InformacoesAdicionaisData = z.infer<typeof formSchema>;

--- a/src/components/dashboard/FormularioUE/FormularioUE.test.tsx
+++ b/src/components/dashboard/FormularioUE/FormularioUE.test.tsx
@@ -337,9 +337,8 @@ describe("FormularioUE", () => {
             etapaEscolar: "Fundamental II",
             frequenciaEscolar: "Regular",
             interacaoAmbienteEscolar: "Boa",
-            redesProtecao: ["CRAS"],
             notificadoConselhoTutelar: "Sim",
-            acompanhadoNAAPA: "Não",
+            acompanhadoNAAPA: "naapa",
         });
 
         mockSecaoFinalGetData.mockReturnValue({
@@ -1043,9 +1042,8 @@ describe("FormularioUE", () => {
                 etapaEscolar: "Fundamental II",
                 frequenciaEscolar: "Regular",
                 interacaoAmbienteEscolar: "Boa",
-                redesProtecao: ["CRAS"],
                 notificadoConselhoTutelar: "Sim",
-                acompanhadoNAAPA: "Não",
+                acompanhadoNAAPA: "naapa",
             });
 
             mockMutate.mockImplementation((data) => {
@@ -1056,7 +1054,7 @@ describe("FormularioUE", () => {
                     ],
                     motivacao_ocorrencia: "Bullying",
                     notificado_conselho_tutelar: true,
-                    acompanhado_naapa: false,
+                    ocorrencia_acompanhada_pelo: "naapa",
                 });
             });
 
@@ -1098,9 +1096,8 @@ describe("FormularioUE", () => {
                     },
                 ],
                 motivoOcorrencia: "Bullying",
-                redesProtecao: ["CRAS"],
                 notificadoConselhoTutelar: "Sim",
-                acompanhadoNAAPA: "Não",
+                acompanhadoNAAPA: "naapa",
             });
 
             mockMutate.mockImplementation((data) => {

--- a/src/components/dashboard/FormularioUE/FormularioUE.tsx
+++ b/src/components/dashboard/FormularioUE/FormularioUE.tsx
@@ -314,17 +314,18 @@ export function FormularioUE({ onNext }: FormularioUEProps) {
                             frequencia_escolar: pessoa.frequenciaEscolar,
                             interacao_ambiente_escolar:
                                 pessoa.interacaoAmbienteEscolar,
+                            nacionalidade: pessoa.nacionalidade,
+                            pessoa_com_deficiencia:
+                                pessoa.pessoaComDeficiencia === "Sim",
                         }),
                     ),
                 motivacao_ocorrencia:
                     informacoesAdicionaisData.motivoOcorrencia,
-                redes_protecao_acompanhamento:
-                    informacoesAdicionaisData.redesProtecao,
                 notificado_conselho_tutelar:
                     informacoesAdicionaisData.notificadoConselhoTutelar ===
                     "Sim",
-                acompanhado_naapa:
-                    informacoesAdicionaisData.acompanhadoNAAPA === "Sim",
+                ocorrencia_acompanhada_pelo:
+                    informacoesAdicionaisData.acompanhadoNAAPA,
             }),
         };
     };

--- a/src/hooks/useAtualizarInfoAgressor.test.tsx
+++ b/src/hooks/useAtualizarInfoAgressor.test.tsx
@@ -41,12 +41,13 @@ describe("useAtualizarInfoAgressor", () => {
                 frequencia_escolar: "transferido_estadual",
                 interacao_ambiente_escolar:
                     "Como é a interação da pessoa agressora no ambiente escolar?",
+                nacionalidade: "Brasileira",
+                pessoa_com_deficiencia: false,
             },
         ],
         motivacao_ocorrencia: ["homofobia", "racismo"],
-        redes_protecao_acompanhamento: "CRAS, NAAPA",
         notificado_conselho_tutelar: true,
-        acompanhado_naapa: false,
+        ocorrencia_acompanhada_pelo: "naapa",
     };
 
     beforeEach(() => {
@@ -68,15 +69,15 @@ describe("useAtualizarInfoAgressor", () => {
                     frequencia_escolar: "transferido_estadual",
                     interacao_ambiente_escolar:
                         "Como é a interação da pessoa agressora no ambiente escolar?",
+                    nacionalidade: "Brasileira",
+                    pessoa_com_deficiencia: false,
                 },
             ],
             motivacao_ocorrencia: ["homofobia", "racismo"],
             motivacao_ocorrencia_display: "Homofobia, Racismo",
-            redes_protecao_acompanhamento: "CRAS, NAAPA",
             notificado_conselho_tutelar: true,
-            acompanhado_naapa: false,
+            ocorrencia_acompanhada_pelo: "naapa",
         };
-
         vi.spyOn(
             atualizarInfoAgressorAction,
             "atualizarInfoAgressor",
@@ -159,15 +160,15 @@ describe("useAtualizarInfoAgressor", () => {
                     frequencia_escolar: "transferido_estadual",
                     interacao_ambiente_escolar:
                         "Como é a interação da pessoa agressora no ambiente escolar?",
+                    nacionalidade: "Brasileira",
+                    pessoa_com_deficiencia: false,
                 },
             ],
             motivacao_ocorrencia: ["homofobia", "racismo"],
             motivacao_ocorrencia_display: "Homofobia, Racismo",
-            redes_protecao_acompanhamento: "CRAS, NAAPA",
             notificado_conselho_tutelar: true,
-            acompanhado_naapa: false,
+            ocorrencia_acompanhada_pelo: "naapa",
         };
-
         const spy = vi
             .spyOn(atualizarInfoAgressorAction, "atualizarInfoAgressor")
             .mockResolvedValue({

--- a/src/lib/transformOcorrenciaToFormData.test.ts
+++ b/src/lib/transformOcorrenciaToFormData.test.ts
@@ -299,6 +299,8 @@ describe("transformOcorrenciaToFormData", () => {
                         etapa_escolar: "ensino_fundamental_2",
                         frequencia_escolar: "regular",
                         interacao_ambiente_escolar: "Boa interação",
+                        nacionalidade: "Brasileira",
+                        pessoa_com_deficiencia: true,
                     },
                 ],
             };
@@ -314,6 +316,8 @@ describe("transformOcorrenciaToFormData", () => {
                     etapaEscolar: "ensino_fundamental_2",
                     frequenciaEscolar: "regular",
                     interacaoAmbienteEscolar: "Boa interação",
+                    nacionalidade: "Brasileira",
+                    pessoaComDeficiencia: "Sim",
                 },
             ]);
         });
@@ -330,6 +334,8 @@ describe("transformOcorrenciaToFormData", () => {
                         etapa_escolar: "ensino_medio",
                         frequencia_escolar: "regular",
                         interacao_ambiente_escolar: "Boa interação",
+                        nacionalidade: "Brasileira",
+                        pessoa_com_deficiencia: false,
                     },
                 ],
             };
@@ -351,6 +357,8 @@ describe("transformOcorrenciaToFormData", () => {
                         etapa_escolar: "",
                         frequencia_escolar: "",
                         interacao_ambiente_escolar: "",
+                        nacionalidade: "",
+                        pessoa_com_deficiencia: false,
                     },
                 ],
             };
@@ -377,15 +385,15 @@ describe("transformOcorrenciaToFormData", () => {
             expect(result.motivoOcorrencia).toEqual(["homofobia", "racismo"]);
         });
 
-        it("deve incluir redes de proteção quando presente", () => {
+        it("deve incluir ocorrencia_acompanhada_pelo quando presente", () => {
             const ocorrencia: OcorrenciaDetalheAPI = {
                 ...baseOcorrencia,
-                redes_protecao_acompanhamento: "CRAS, NAAPA",
+                ocorrencia_acompanhada_pelo: "naapa",
             };
 
             const result = transformOcorrenciaToFormData(ocorrencia);
 
-            expect(result.redesProtecao).toBe("CRAS, NAAPA");
+            expect(result.acompanhadoNAAPA).toBe("naapa");
         });
 
         it("deve converter notificado_conselho_tutelar para 'Sim' quando true", () => {
@@ -410,26 +418,26 @@ describe("transformOcorrenciaToFormData", () => {
             expect(result.notificadoConselhoTutelar).toBe("Não");
         });
 
-        it("deve converter acompanhado_naapa para 'Sim' quando true", () => {
+        it("deve converter acompanhado_naapa para o valor de ocorrencia_acompanhada_pelo", () => {
             const ocorrencia: OcorrenciaDetalheAPI = {
                 ...baseOcorrencia,
-                acompanhado_naapa: true,
+                ocorrencia_acompanhada_pelo: "comissao_mediacao_conflitos",
             };
 
             const result = transformOcorrenciaToFormData(ocorrencia);
 
-            expect(result.acompanhadoNAAPA).toBe("Sim");
+            expect(result.acompanhadoNAAPA).toBe("comissao_mediacao_conflitos");
         });
 
-        it("deve converter acompanhado_naapa para 'Não' quando false", () => {
+        it("não deve incluir acompanhadoNAAPA quando ocorrencia_acompanhada_pelo é undefined", () => {
             const ocorrencia: OcorrenciaDetalheAPI = {
                 ...baseOcorrencia,
-                acompanhado_naapa: false,
+                ocorrencia_acompanhada_pelo: undefined,
             };
 
             const result = transformOcorrenciaToFormData(ocorrencia);
 
-            expect(result.acompanhadoNAAPA).toBe("Não");
+            expect(result.acompanhadoNAAPA).toBeUndefined();
         });
 
         it("não deve incluir notificadoConselhoTutelar quando undefined", () => {
@@ -441,17 +449,6 @@ describe("transformOcorrenciaToFormData", () => {
             const result = transformOcorrenciaToFormData(ocorrencia);
 
             expect(result.notificadoConselhoTutelar).toBeUndefined();
-        });
-
-        it("não deve incluir acompanhadoNAAPA quando undefined", () => {
-            const ocorrencia: OcorrenciaDetalheAPI = {
-                ...baseOcorrencia,
-                acompanhado_naapa: undefined,
-            };
-
-            const result = transformOcorrenciaToFormData(ocorrencia);
-
-            expect(result.acompanhadoNAAPA).toBeUndefined();
         });
     });
 
@@ -469,15 +466,16 @@ describe("transformOcorrenciaToFormData", () => {
                         frequencia_escolar: "transferido_estadual",
                         interacao_ambiente_escolar:
                             "Como é a interação da pessoa agressora no ambiente escolar?",
+                        nacionalidade: "Brasileira",
+                        pessoa_com_deficiencia: false,
                     },
                 ],
                 motivacao_ocorrencia_display: [
                     { value: "homofobia", label: "Homofobia" },
                     { value: "racismo", label: "Racismo" },
                 ],
-                redes_protecao_acompanhamento: "CRAS, NAAPA",
                 notificado_conselho_tutelar: true,
-                acompanhado_naapa: false,
+                ocorrencia_acompanhada_pelo: "naapa",
             };
 
             const result = transformOcorrenciaToFormData(ocorrencia);
@@ -493,12 +491,13 @@ describe("transformOcorrenciaToFormData", () => {
                         frequenciaEscolar: "transferido_estadual",
                         interacaoAmbienteEscolar:
                             "Como é a interação da pessoa agressora no ambiente escolar?",
+                        nacionalidade: "Brasileira",
+                        pessoaComDeficiencia: "Não",
                     },
                 ],
                 motivoOcorrencia: ["homofobia", "racismo"],
-                redesProtecao: "CRAS, NAAPA",
                 notificadoConselhoTutelar: "Sim",
-                acompanhadoNAAPA: "Não",
+                acompanhadoNAAPA: "naapa",
             });
         });
     });

--- a/src/lib/transformOcorrenciaToFormData.ts
+++ b/src/lib/transformOcorrenciaToFormData.ts
@@ -88,6 +88,10 @@ function extractDadosPessoaisAgressor(ocorrencia: OcorrenciaDetalheAPI) {
                 frequenciaEscolar: pessoa.frequencia_escolar || "",
                 interacaoAmbienteEscolar:
                     pessoa.interacao_ambiente_escolar || "",
+                nacionalidade: pessoa.nacionalidade || "",
+                pessoaComDeficiencia: pessoa.pessoa_com_deficiencia
+                    ? "Sim"
+                    : "Não",
             })),
         }),
     };
@@ -100,7 +104,6 @@ function extractDadosEscolaresAgressor(ocorrencia: OcorrenciaDetalheAPI) {
     const notificadoConselhoTutelar = getBooleanAsSimNao(
         ocorrencia.notificado_conselho_tutelar,
     );
-    const acompanhadoNAAPA = getBooleanAsSimNao(ocorrencia.acompanhado_naapa);
     const motivoOcorrencia = ocorrencia.motivacao_ocorrencia_display?.map(
         (item) => item.value,
     );
@@ -109,11 +112,10 @@ function extractDadosEscolaresAgressor(ocorrencia: OcorrenciaDetalheAPI) {
         ...(motivoOcorrencia && {
             motivoOcorrencia,
         }),
-        ...(ocorrencia.redes_protecao_acompanhamento && {
-            redesProtecao: ocorrencia.redes_protecao_acompanhamento,
-        }),
         ...(notificadoConselhoTutelar && { notificadoConselhoTutelar }),
-        ...(acompanhadoNAAPA && { acompanhadoNAAPA }),
+        ...(ocorrencia.ocorrencia_acompanhada_pelo && {
+            acompanhadoNAAPA: ocorrencia.ocorrencia_acompanhada_pelo,
+        }),
     };
 }
 

--- a/src/types/formulario-completo-ue.ts
+++ b/src/types/formulario-completo-ue.ts
@@ -20,11 +20,12 @@ export type FormularioCompletoUEBody = {
         etapa_escolar: string;
         frequencia_escolar: string;
         interacao_ambiente_escolar: string;
+        nacionalidade: string;
+        pessoa_com_deficiencia: boolean;
     }>;
     motivacao_ocorrencia?: string[];
-    redes_protecao_acompanhamento?: string;
     notificado_conselho_tutelar?: boolean;
-    acompanhado_naapa?: boolean;
+    ocorrencia_acompanhada_pelo?: string;
 };
 
 export type FormularioCompletoUEResponse = {
@@ -46,9 +47,10 @@ export type FormularioCompletoUEResponse = {
         etapa_escolar: string;
         frequencia_escolar: string;
         interacao_ambiente_escolar: string;
+        nacionalidade: string;
+        pessoa_com_deficiencia: boolean;
     }>;
     motivacao_ocorrencia?: string[];
-    redes_protecao_acompanhamento?: string;
     notificado_conselho_tutelar?: boolean;
-    acompanhado_naapa?: boolean;
+    ocorrencia_acompanhada_pelo?: string;
 };

--- a/src/types/formulario-completo-ue.ts
+++ b/src/types/formulario-completo-ue.ts
@@ -25,7 +25,11 @@ export type FormularioCompletoUEBody = {
     }>;
     motivacao_ocorrencia?: string[];
     notificado_conselho_tutelar?: boolean;
-    ocorrencia_acompanhada_pelo?: string;
+    ocorrencia_acompanhada_pelo?:
+        | "naapa"
+        | "comissao_mediacao_conflitos"
+        | "supervisao_escolar"
+        | "cefai";
 };
 
 export type FormularioCompletoUEResponse = {
@@ -52,5 +56,9 @@ export type FormularioCompletoUEResponse = {
     }>;
     motivacao_ocorrencia?: string[];
     notificado_conselho_tutelar?: boolean;
-    ocorrencia_acompanhada_pelo?: string;
+    ocorrencia_acompanhada_pelo?:
+        | "naapa"
+        | "comissao_mediacao_conflitos"
+        | "supervisao_escolar"
+        | "cefai";
 };

--- a/src/types/info-agressor.ts
+++ b/src/types/info-agressor.ts
@@ -6,6 +6,8 @@ export type PessoaAgressora = {
     etapa_escolar: string;
     frequencia_escolar: string;
     interacao_ambiente_escolar: string;
+    nacionalidade: string;
+    pessoa_com_deficiencia: boolean;
 };
 
 export type InfoAgressorBody = {
@@ -13,9 +15,8 @@ export type InfoAgressorBody = {
     dre_codigo_eol: string;
     pessoas_agressoras: PessoaAgressora[];
     motivacao_ocorrencia: string[];
-    redes_protecao_acompanhamento: string;
     notificado_conselho_tutelar: boolean;
-    acompanhado_naapa: boolean;
+    ocorrencia_acompanhada_pelo: string;
 };
 
 export type InfoAgressorResponse = {
@@ -25,7 +26,6 @@ export type InfoAgressorResponse = {
     pessoas_agressoras: PessoaAgressora[];
     motivacao_ocorrencia: string[];
     motivacao_ocorrencia_display: string;
-    redes_protecao_acompanhamento: string;
     notificado_conselho_tutelar: boolean;
-    acompanhado_naapa: boolean;
+    ocorrencia_acompanhada_pelo: string;
 };


### PR DESCRIPTION
Esse PR:

- Retira a palavra “envolvida” da pergunta “Qual o nome da pessoa envolvida?*
- Inclui um campo “nacionalidade”. Será campo de digitação obrigatório
- Insere uma tooltip com o texto “A nacionalidade corresponde ao país de nascimento.”
- Insere um campo “pessoa com deficiência?” 
- Retira a pergunta “Quais órgãos da rede de proteção já acompanham o estudante?*”
- A pergunta “A ocorrência foi notificada ao Conselho Tutelar?” substituída por “A ocorrência foi notificada ao CT (Conselho Tutelar?)*”
- A pergunta “ A ocorrência é acompanhada pelo NAAPA?” substituída por “A ocorrência está sendo acompanhada pelo:” com novas opções de resposta:
- Testes unitários

Historia: [AB#145713](https://dev.azure.com/SME-Spassu/7e92ae7b-7c5d-42b3-8ccb-3229aa6f7d19/_workitems/edit/145713) e tarefa: [AB#145753](https://dev.azure.com/SME-Spassu/7e92ae7b-7c5d-42b3-8ccb-3229aa6f7d19/_workitems/edit/145753) 