### PR TITLE
Feature/145749: Aviso select anexos

### DIFF
--- a/src/components/dashboard/CadastrarOcorrencia/Anexos/index.test.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/Anexos/index.test.tsx
@@ -1354,4 +1354,103 @@ describe("Anexos", () => {
             expect(button).toHaveClass("cursor-not-allowed");
         });
     });
+
+    describe("alerta de imagens", () => {
+        beforeEach(() => {
+            vi.spyOn(
+                useTiposDocumentosHook,
+                "useTiposDocumentos",
+            ).mockReturnValue({
+                data: [
+                    {
+                        value: "boletim_ocorrencia",
+                        label: "Boletim de ocorrência",
+                    },
+                    { value: "imagens", label: "Imagens" },
+                ],
+                isLoading: false,
+                isError: false,
+                error: null,
+            } as never);
+        });
+
+        it("deve exibir o alerta ao selecionar o tipo Imagens", async () => {
+            const user = userEvent.setup();
+            renderWithProvider(
+                <Anexos onPrevious={mockOnPrevious} onNext={mockOnNext} />,
+            );
+
+            expect(
+                screen.queryByText(/A imagem não deve conter pessoas/i),
+            ).not.toBeInTheDocument();
+
+            const tipoSelect = screen.getByRole("combobox", {
+                name: /Tipo do documento/i,
+            });
+            await user.click(tipoSelect);
+            await user.click(
+                await screen.findByRole("option", { name: /^Imagens$/i }),
+            );
+
+            expect(
+                screen.getByText(/A imagem não deve conter pessoas/i),
+            ).toBeInTheDocument();
+        });
+
+        it("deve ocultar o alerta ao trocar para outro tipo", async () => {
+            const user = userEvent.setup();
+            renderWithProvider(
+                <Anexos onPrevious={mockOnPrevious} onNext={mockOnNext} />,
+            );
+
+            const tipoSelect = screen.getByRole("combobox", {
+                name: /Tipo do documento/i,
+            });
+            await user.click(tipoSelect);
+            await user.click(
+                await screen.findByRole("option", { name: /^Imagens$/i }),
+            );
+
+            expect(
+                screen.getByText(/A imagem não deve conter pessoas/i),
+            ).toBeInTheDocument();
+
+            await user.click(tipoSelect);
+            await user.click(
+                await screen.findByRole("option", { name: /Boletim/i }),
+            );
+
+            expect(
+                screen.queryByText(/A imagem não deve conter pessoas/i),
+            ).not.toBeInTheDocument();
+        });
+
+        it("deve exibir o alerta novamente ao selecionar Imagens após trocar de tipo", async () => {
+            const user = userEvent.setup();
+            renderWithProvider(
+                <Anexos onPrevious={mockOnPrevious} onNext={mockOnNext} />,
+            );
+
+            const tipoSelect = screen.getByRole("combobox", {
+                name: /Tipo do documento/i,
+            });
+
+            await user.click(tipoSelect);
+            await user.click(
+                await screen.findByRole("option", { name: /^Imagens$/i }),
+            );
+            await user.click(tipoSelect);
+            await user.click(
+                await screen.findByRole("option", { name: /Boletim/i }),
+            );
+            await user.click(tipoSelect);
+            await user.click(
+                await screen.findByRole("option", { name: /^Imagens$/i }),
+            );
+
+            expect(
+                screen.getByText(/A imagem não deve conter pessoas/i),
+            ).toBeInTheDocument();
+        });
+    });
 });

--- a/src/components/dashboard/CadastrarOcorrencia/Anexos/index.tsx
+++ b/src/components/dashboard/CadastrarOcorrencia/Anexos/index.tsx
@@ -302,6 +302,20 @@ export default function Anexos({
                                                     documento para anexar
                                                 </p>
                                             )}
+                                            {tiposDocumento.find(
+                                                (t) =>
+                                                    t.value === field.value &&
+                                                    t.label.toLowerCase() ===
+                                                        "imagens",
+                                            ) && (
+                                                <p
+                                                    className="text-sm"
+                                                    style={{ color: "#B40C02" }}
+                                                >
+                                                    A imagem não deve conter
+                                                    pessoas
+                                                </p>
+                                            )}
                                         </FormItem>
                                     )}
                                 />


### PR DESCRIPTION
Esse PR:

- Adicionado alerta quando seleciona tipo de documento "imagens" exibe alerta de "A imagem não deve conter pessoas”
- Novos testes

Historia: [AB#145711](https://dev.azure.com/SME-Spassu/7e92ae7b-7c5d-42b3-8ccb-3229aa6f7d19/_workitems/edit/145711) e tarefa: [AB#145749](https://dev.azure.com/SME-Spassu/7e92ae7b-7c5d-42b3-8ccb-3229aa6f7d19/_workitems/edit/145749)